### PR TITLE
V06 review suggestions

### DIFF
--- a/draft-ietf-dnsop-dns-catalog-zones.md
+++ b/draft-ietf-dnsop-dns-catalog-zones.md
@@ -305,28 +305,27 @@ The exact handling of configuration referred to by the `group` property value is
 The property is defined by a TXT record in the sub-node labelled `group`.
 
 The producer MAY assign a `group` property to all, some, or none of the member zones within a catalog zone.
-The producer MUST NOT assign more than one `group` property to one member zone.
+The producer MAY assign morte than one `group` property to one member zone. This will make it possible to transfer group information for different consumer operators in a single catalog zone.
+Consumer operators SHOULD namespace their group properties to limit risk of clashes.
 
-The consumer MUST ignore either all or none of the `group` properties in a catalog zone.
-
-The value of the TXT record MUST be at most 255 octets long and MUST NOT contain whitespace characters.
-The consumer MUST interpret the value case-sensitively.
-
-A `group` property with an invalid value or a `group` property with more than one record in the RRset, denotes a broken catalog zone which MUST NOT be processed (see (#generalrequirements)).
-The reason a catalog zone is considered broken SHOULD always be communicated clearly to the operator (e.g. through a log message).
+The consumer MUST ignore `group` properties it does not understand.
 
 #### Example
 
 ```
 <unique-1>.zones.$CATZ        0 IN PTR    example.com.
-group.<unique-1>.zones.$CATZ  0 IN TXT    sign-with-nsec3
+group.<unique-1>.zones.$CATZ  0 IN TXT    nodnssec
 <unique-2>.zones.$CATZ        0 IN PTR    example.net.
-group.<unique-2>.zones.$CATZ  0 IN TXT    nodnssec
+group.<unique-2>.zones.$CATZ  0 IN TXT    operator-x-sign-with-nsec3
+group.<unique-2>.zones.$CATZ  0 IN TXT    operator-y-nsec3
+
 ```
 
-In this case, the consumer might be implemented and configured in the way that the member zones with "nodnssec" group assigned will not be signed with DNSSEC, and the zones with "sign-with-nsec3" group assigned will be signed with DNSSEC with NSEC3 chain.
+The catalog zone (snippet) above is an example where the producer signals how the consumer(s) shall treat DNSSEC for the zones example.net. and example.com.
 
-By generating the catalog zone (snippet) above, the producer signals how the consumer shall treat DNSSEC for the zones example.net. and example.com., respectively.
+For example.com., the consumer might be implemented and configured in the way that the member zone will not be signed with DNSSEC.
+For example.net., the consumers, at two different operators, might be implemented and configured in the way that the member zone will be signed with a NSEC3 chain.
+
 
 ## Custom Properties (`*.ext` properties) {#customproperties}
 

--- a/draft-ietf-dnsop-dns-catalog-zones.md
+++ b/draft-ietf-dnsop-dns-catalog-zones.md
@@ -216,8 +216,8 @@ querying via recursive resolvers.
 
 ## Properties
 
-Apart from catalog zone metadata stored at the apex (NS, SOA and the like), catalog zone information is stored in the form of "properties".
-Catalog consumers SHOULD ignore properties they do not understand.
+Catalog zone information is stored in the form of "properties".
+Catalog consumers SHOULD ignore records they do not understand.
 
 Properties are identified by their name, which is used as an owner name prefix for one or more record sets underneath a member node, with type(s) as appropriate for the respective property.
 Record sets that appear at a property owner name known to the catalog consumer but with an unknown RR type, SHOULD be ignored by the consumer.

--- a/draft-ietf-dnsop-dns-catalog-zones.md
+++ b/draft-ietf-dnsop-dns-catalog-zones.md
@@ -176,7 +176,7 @@ defined in [@!RFC1982].  Otherwise, catalog consumers might not notice
 updates to the catalog zone's contents.
 
 There is no requirement to be able to query the catalog zone via recursive nameservers.
-Catalog consumers MUST ignore and MUST NOT assume or require NS records at the apex.
+Catalog consumers SHOULD ignore NS record at apex.
 However, at least one is still required so that catalog zones are syntactically correct DNS zones.
 A single NS RR with a NSDNAME field containing the absolute name "invalid." is RECOMMENDED [@!RFC2606;@!RFC6761].
 


### PR DESCRIPTION
My review for #45

1. NS records are sometime useful for the implementation. Ignore them completely is not possible.
2. Be more clear that a catalog consumer should ignore ALL Records it does not understand
3. Try to improve the wording about coo
4. Group properties are agreed between the consumer and producer operator. There is no need to be this restrictive about the exact format in the draft. This pull is also adding multiple groups per zone. This will make it possible to send the same catalog to multiple operators with different group requirement. This will simplify management of catalog zones greatly since it no longer necessary to create a catalog per operator (and keep those in sync).
